### PR TITLE
Added glbinding

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ A curated list of awesome OpenGL libraries, debuggers and resources. Inspired by
 * [gl3w](https://github.com/skaslev/gl3w) - A simple OpenGL core profile loader.
 * [glad](https://github.com/Dav1dde/glad) - A multi profile loader-generator based on the official specs.
 * [glbindify](https://github.com/nnesse/glbindify) - A commmand line tool to generate C bindings for OpenGL, wgl, and glX.
+* [glbinding](https://github.com/cginternals/glbinding) - A profile loader leveraging C++11 features to provide type safety.
 * [GLEW](http://glew.sourceforge.net) - A mature cross-platform library to load OpenGL extensions.
 * [glLoadGen](https://bitbucket.org/alfonse/glloadgen/wiki/Home) - A multi profile loader-generator written in Lua.
 


### PR DESCRIPTION
Added [`glbinding`](https://github.com/cginternals/glbinding), a profile loader that seems to be quite popular and has some useful features, such as not using macros, better type enforcing (for example detecting when wrong type of enums is used) and more.
