### PR TITLE
add FLTK to Libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ A curated list of awesome OpenGL libraries, debuggers and resources.
 
 * [assimp](https://github.com/assimp/assimp) - Portable library to import 3D models in a uniform manner.
 * [Bullet](http://bulletphysics.org/wordpress) - It provides state of the art collision detection, soft body and rigid body dynamics.
+* [fltk](https://www.fltk.org/) - C++ Toolkit to generate UI widgets portably. [GPLv2](https://www.fltk.org/COPYING.php)
 * [freeGLUT](http://freeglut.sourceforge.net) - Mature library that allows to create/manage windows containing OpenGL contexts.
 * [GLFW](http://www.glfw.org) - Modern library for creating/interact windows with OpenGL contexts.
 * [GLFM](https://github.com/brackeen/glfm) - Supplies an OpenGL ES context and input events for mobile devices and the web.


### PR DESCRIPTION
Add link to https://www.fltk.org/ under Libraries.